### PR TITLE
test: add current Xquik OpenAPI coverage and fix sample schema

### DIFF
--- a/packages/cli/examples/sample-api.yaml
+++ b/packages/cli/examples/sample-api.yaml
@@ -28,7 +28,22 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
+                  type: object
+                  required:
+                    - id
+                    - name
+                    - username
+                    - email
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    username:
+                      type: string
+                    email:
+                      type: string
+                      format: email
 
     post:
       summary: Create a new user

--- a/packages/cli/examples/xquik-api.yaml
+++ b/packages/cli/examples/xquik-api.yaml
@@ -1,7 +1,10 @@
 openapi: 3.1.0
 info:
   title: Xquik API
-  version: 1.0.0
+  version: "1.0"
+  description: >-
+    Search public X posts. Xquik is an independent third-party service. Not
+    affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 servers:
   - url: https://xquik.com
 security:
@@ -9,7 +12,7 @@ security:
 paths:
   /api/v1/x/tweets/search:
     get:
-      summary: Search X posts
+      summary: Search posts by query, post ID, X status URL, or account date window
       operationId: searchTweets
       parameters:
         - name: q
@@ -21,11 +24,27 @@ paths:
         - name: limit
           in: query
           required: false
-          description: Maximum number of posts to return
+          description: Maximum number of posts to return across paginated results
           schema:
             type: integer
-            minimum: 1
-            maximum: 100
+            default: 20
+            maximum: 200
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor from the previous response
+          schema:
+            type: string
+        - name: queryType
+          in: query
+          required: false
+          description: Sort results chronologically or by engagement
+          schema:
+            type: string
+            enum:
+              - Latest
+              - Top
+            default: Latest
       responses:
         "200":
           description: Search results
@@ -34,9 +53,11 @@ paths:
               schema:
                 type: object
                 required:
-                  - data
+                  - tweets
+                  - has_next_page
+                  - next_cursor
                 properties:
-                  data:
+                  tweets:
                     type: array
                     items:
                       type: object
@@ -48,9 +69,14 @@ paths:
                           type: string
                         text:
                           type: string
-                        authorUsername:
-                          type: string
-                  nextCursor:
+                        author:
+                          type: object
+                          properties:
+                            username:
+                              type: string
+                  has_next_page:
+                    type: boolean
+                  next_cursor:
                     type: string
 components:
   securitySchemes:

--- a/packages/cli/examples/xquik-api.yaml
+++ b/packages/cli/examples/xquik-api.yaml
@@ -1,0 +1,60 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: 1.0.0
+servers:
+  - url: https://xquik.com
+security:
+  - xApiKey: []
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      summary: Search X posts
+      operationId: searchTweets
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of posts to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - text
+                      properties:
+                        id:
+                          type: string
+                        text:
+                          type: string
+                        authorUsername:
+                          type: string
+                  nextCursor:
+                    type: string
+components:
+  securitySchemes:
+    xApiKey:
+      type: apiKey
+      in: header
+      name: x-api-key

--- a/packages/sdk/src/lib.test.ts
+++ b/packages/sdk/src/lib.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SAMPLE_SPEC = path.resolve(__dirname, '../../cli/examples/sample-api.yaml');
+const XQUIK_SPEC = path.resolve(__dirname, '../../cli/examples/xquik-api.yaml');
 
 describe('createTools', () => {
   it('returns a ToolSet with one tool per operation', async () => {
@@ -57,6 +58,22 @@ describe('createTools', () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  it('can load an OpenAPI 3.1 spec with API key auth in code mode', async () => {
+    const tools = await createTools({ spec: XQUIK_SPEC, codeMode: true });
+    expect(Object.keys(tools).sort()).toEqual(['execute', 'search']);
+
+    const searchTool = tools['search'];
+    const exec = 'execute' in searchTool ? searchTool.execute : undefined;
+
+    const result = await exec!(
+      { query: 'tweets' },
+      { toolCallId: 'x', messages: [], abortSignal: new AbortController().signal }
+    ) as string;
+
+    expect(result).toContain('searchTweets');
+    expect(result).toContain('Search X posts');
   });
 
   describe('codeMode', () => {

--- a/packages/sdk/src/lib.test.ts
+++ b/packages/sdk/src/lib.test.ts
@@ -73,7 +73,7 @@ describe('createTools', () => {
     ) as string;
 
     expect(result).toContain('searchTweets');
-    expect(result).toContain('Search X posts');
+    expect(result).toContain('Search posts by query');
   });
 
   describe('codeMode', () => {


### PR DESCRIPTION
## Summary

- Add a compact, current Xquik OpenAPI 3.1 example spec.
- Verify code mode loads an API-key-protected OpenAPI 3.1 spec and finds its search operation.
- Fix the existing JSONPlaceholder sample response schema to describe user objects instead of strings.

## Accuracy

- Match the live Xquik search contract: a 200-result limit, cursor and sort parameters, and current pagination fields.
- Include the required X Corp. independence and trademark disclosure.

## Validation

- `pnpm build`
- `pnpm test` - 35 tests passed
- `pnpm typecheck`
- Parsed both changed YAML examples successfully.
- Compared the Xquik example against `https://xquik.com/openapi.yaml`.
- `git diff --check`
